### PR TITLE
3: Fix TOCSidebar sticky positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lem/ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/TOCSidebar.tsx
+++ b/src/components/TOCSidebar.tsx
@@ -46,7 +46,7 @@ export function TOCSidebar({
 
   return (
     <aside
-      className={`hidden w-44 shrink-0 self-start pt-4 lg:block ${className}`}
+      className={`hidden w-44 shrink-0 pt-4 lg:block ${className}`}
       aria-label="Table of contents"
     >
       <div className="sticky top-8">


### PR DESCRIPTION
## Summary

Remove `self-start` from TOCSidebar `<aside>` to fix sticky positioning.

## Changes

- Removed `self-start` Tailwind class from the aside element in TOCSidebar
- Version bump to 0.5.1

## Test Plan

- In a flex row layout with TOCSidebar + article, scroll down and verify the TOC sticks to the viewport
- Verified fix in lem-fyi locally

## Issue

Closes #3