### PR TITLE
#16: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lucas McComb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@lem/ui",
   "version": "0.5.1",
+  "license": "MIT",
+  "author": "Lucas McComb",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Closes #16

Adds a top-level MIT `LICENSE` (Copyright (c) 2026 Lucas McComb) and `"license": "MIT"` + `"author": "Lucas McComb"` to package.json, clearing the `tos-compliance/unlicensed-dependency` audit finding for `@lem/ui` in the public lem.work bundle.

**Consumption / republish note:** `@lem/ui` is not published to any npm registry (`npm view @lem/ui` returns 404). lem-work consumes it as a git dependency (`"@lem/ui": "github:lucasmccomb/lem-ui"` in `client/package.json`). No version bump is needed — consumers pick up the license metadata automatically on their next `npm install` (git deps re-fetch the default-branch HEAD). Once this merges to `main`, a fresh install in lem-work will carry the license; no dependency-version change in lem-work is required.